### PR TITLE
Remove docker network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       SMTP_PORT: 1025
       JENKINS_EMAIL_SUFFIX: '@exoplatform.com'
       JENKINS_REPLYTO_ADDR: exo-swf@exoplatform.com
-      JENKINS_DOCKER_RUN_PARAMS: -u 0:0 --network=swfjenkinspipelinedev_swf
+      JENKINS_DOCKER_RUN_PARAMS: -u 0:0
       JENKINS_USER: exo-ci
       JENKINS_PASSWORD: exo-ci
       JENKINS_MASTER_EXECUTORS: 0


### PR DESCRIPTION
I don't get why we enforce a network for jenkins' Docker run parameter (`--network=swfjenkinspipelinedev_swf`).
I have started a jnlp jenkins agent on a machine which is not the one which started the jenkins2 + mail + git services, and this network is of course not present on the agent machine. Everything seems to work without this parameter.

Any reason to keep it ?